### PR TITLE
create HIR Base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,8 +110,10 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 name = "cmd"
 version = "0.1.0"
 dependencies = [
+ "ast",
  "clap",
  "parser",
+ "to_hir",
 ]
 
 [[package]]
@@ -333,6 +335,11 @@ dependencies = [
 [[package]]
 name = "to_hir"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ast",
+ "hir",
+]
 
 [[package]]
 name = "toml"

--- a/debug_util/cmd/Cargo.toml
+++ b/debug_util/cmd/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.4.11", features = ["derive"] }
 parser = { path = "../../libs/compiler/converts/parser" }
+to_hir = { path = "../../libs/compiler/converts/to_hir" }
+ast = { path = "../../libs/compiler/defs/ast" }

--- a/debug_util/cmd/src/main.rs
+++ b/debug_util/cmd/src/main.rs
@@ -1,6 +1,8 @@
+use ast::{AstContext, AstDir, AstModule, AstSource};
 use clap::Parser;
 use parser::parse;
 use std::{fs::File, io::Read, path::PathBuf};
+use to_hir::into_hir;
 
 #[derive(Debug, Parser)]
 struct Cmd {
@@ -17,6 +19,18 @@ fn main() {
             .unwrap_or_else(|_| panic!("can't load file: {}", cmd.path.display()));
         data
     };
-    let _ast = parse(&code);
-    // let _ = dbg!(ast);
+    let _ast = dbg!(parse(&code)).unwrap();
+    let _hir = dbg!(into_hir(AstContext {
+        modules: vec![AstModule {
+            name: "main".to_string(),
+            dirs: AstDir {
+                name: "__ROOT__".to_string(),
+                dirs: vec![],
+                source: vec![AstSource {
+                    name: "main.meg".to_string(),
+                    defs: _ast,
+                }],
+            }
+        }]
+    }));
 }

--- a/debug_util/files/fn.meg
+++ b/debug_util/files/fn.meg
@@ -1,3 +1,3 @@
 fn test() [
-    mut a: type = "test"
+    Print("a")
 ]

--- a/libs/compiler/converts/parser/src/parsers.rs
+++ b/libs/compiler/converts/parser/src/parsers.rs
@@ -236,9 +236,9 @@ peg::parser! {
             / lit:p_value() { AstExpr::Lit(lit) }
 
         /// call func
-        pub(super) rule p_call_func() -> CallFunc =
+        pub(super) rule p_call_func() -> AstCallFunc =
             name:ref_dot() n() t_lparen() n() args:(p_expr() ** (n() t_comma() n())) n() t_rparen() {
-                CallFunc {
+                AstCallFunc {
                     name,
                     args,
                 }
@@ -390,16 +390,16 @@ mod tests {
 
             // Expected AST representation of the function inner statements
             let expect = vec![
-                ast::AstStmt::Expr(ast::AstExpr::CallFunc(ast::CallFunc {
+                ast::AstStmt::Expr(ast::AstExpr::CallFunc(ast::AstCallFunc {
                     name: vec!["call_func".to_string()],
-                    args: vec![ast::AstExpr::CallFunc(ast::CallFunc {
+                    args: vec![ast::AstExpr::CallFunc(ast::AstCallFunc {
                         name: vec!["call_func".to_string()],
                         args: vec![],
                     })],
                 })),
-                ast::AstStmt::Expr(ast::AstExpr::CallFunc(ast::CallFunc {
+                ast::AstStmt::Expr(ast::AstExpr::CallFunc(ast::AstCallFunc {
                     name: vec!["test".to_string(), "call_func".to_string()],
-                    args: vec![ast::AstExpr::CallFunc(ast::CallFunc {
+                    args: vec![ast::AstExpr::CallFunc(ast::AstCallFunc {
                         name: vec!["call_func".to_string()],
                         args: vec![],
                     })],
@@ -552,9 +552,9 @@ mod tests {
             let result = megu_parser::p_stmt(&tokens);
 
             // Expected AST representation of the statement
-            let expect = ast::AstStmt::Expr(ast::AstExpr::CallFunc(ast::CallFunc {
+            let expect = ast::AstStmt::Expr(ast::AstExpr::CallFunc(ast::AstCallFunc {
                 name: vec!["call_func".to_string()],
-                args: vec![ast::AstExpr::CallFunc(ast::CallFunc {
+                args: vec![ast::AstExpr::CallFunc(ast::AstCallFunc {
                     name: vec!["call_func".to_string()],
                     args: vec![],
                 })],
@@ -583,9 +583,9 @@ mod tests {
                 v_type: ast::AstType {
                     refs: vec!["Type1".to_string(), "Ref".to_string()],
                 },
-                value: ast::AstExpr::CallFunc(ast::CallFunc {
+                value: ast::AstExpr::CallFunc(ast::AstCallFunc {
                     name: vec!["call_func".to_string()],
-                    args: vec![ast::AstExpr::CallFunc(ast::CallFunc {
+                    args: vec![ast::AstExpr::CallFunc(ast::AstCallFunc {
                         name: vec!["call_func".to_string()],
                         args: vec![],
                     })],
@@ -615,9 +615,9 @@ mod tests {
                 v_type: ast::AstType {
                     refs: vec!["Type1".to_string(), "Ref".to_string()],
                 },
-                value: ast::AstExpr::CallFunc(ast::CallFunc {
+                value: ast::AstExpr::CallFunc(ast::AstCallFunc {
                     name: vec!["call_func".to_string()],
-                    args: vec![ast::AstExpr::CallFunc(ast::CallFunc {
+                    args: vec![ast::AstExpr::CallFunc(ast::AstCallFunc {
                         name: vec!["call_func".to_string()],
                         args: vec![],
                     })],

--- a/libs/compiler/converts/to_hir/Cargo.toml
+++ b/libs/compiler/converts/to_hir/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ast = { path = "../../defs/ast" }
+hir = { path = "../../defs/hir" }
+anyhow.workspace = true

--- a/libs/compiler/converts/to_hir/src/defs.rs
+++ b/libs/compiler/converts/to_hir/src/defs.rs
@@ -1,0 +1,51 @@
+use std::collections::HashMap;
+
+use ast::{AstDef, AstExpr, AstLitValues, AstStmt};
+use hir::{HirCallFunc, HirExpr, HirItem, HirItemType, HirStmt};
+
+pub(crate) fn into_defs(
+    defs: Vec<(Vec<String>, AstDef)>,
+    mod_name: String,
+) -> HashMap<Vec<String>, HirItem> {
+    let mut res = HashMap::new();
+
+    for (place, def) in defs {
+        match def {
+            AstDef::Func(func) => {
+                res.insert(
+                    vec![mod_name.clone(), func.name /* 仮 */],
+                    HirItem {
+                        place,
+                        item_type: HirItemType::Fn(hir::HirFn {
+                            body: func.inner.into_iter().map(into_stmt).collect(),
+                        }),
+                    },
+                );
+            }
+            _ => todo!(),
+        }
+    }
+
+    res
+}
+
+pub(crate) fn into_stmt(stmt: AstStmt) -> HirStmt {
+    match stmt {
+        AstStmt::Expr(expr) => HirStmt::Expr(into_expr(expr)),
+        _ => todo!(),
+    }
+}
+
+pub(crate) fn into_expr(expr: AstExpr) -> HirExpr {
+    match expr {
+        AstExpr::CallFunc(func) => HirExpr::CallFunc(HirCallFunc {
+            name: func.name,
+            args: func.args.into_iter().map(into_expr).collect(),
+        }),
+        AstExpr::Lit(lit) => match lit {
+            AstLitValues::Number(n) => HirExpr::LitInt(n),
+            AstLitValues::String(s) => HirExpr::LitStr(s),
+            _ => todo!(),
+        },
+    }
+}

--- a/libs/compiler/converts/to_hir/src/defs.rs
+++ b/libs/compiler/converts/to_hir/src/defs.rs
@@ -45,7 +45,6 @@ pub(crate) fn into_expr(expr: AstExpr) -> HirExpr {
         AstExpr::Lit(lit) => match lit {
             AstLitValues::Number(n) => HirExpr::LitInt(n),
             AstLitValues::String(s) => HirExpr::LitStr(s),
-            _ => todo!(),
         },
     }
 }

--- a/libs/compiler/defs/ast/src/exprs.rs
+++ b/libs/compiler/defs/ast/src/exprs.rs
@@ -2,12 +2,12 @@ use crate::*;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AstExpr {
-    CallFunc(CallFunc),
+    CallFunc(AstCallFunc),
     Lit(AstLitValues),
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct CallFunc {
+pub struct AstCallFunc {
     pub name: Vec<String>,
     pub args: Vec<AstExpr>,
 }

--- a/libs/compiler/defs/hir/src/lib.rs
+++ b/libs/compiler/defs/hir/src/lib.rs
@@ -1,14 +1,48 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HirCtx {
+    pub mods: Vec<HirMod>,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[derive(Debug, Clone, PartialEq)]
+pub struct HirMod {
+    pub name: String,
+    pub items: HashMap<Vec<String>, HirItem>,
+}
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
+#[derive(Debug, Clone, PartialEq)]
+pub struct HirItem {
+    pub place: Vec<String>, // "__ROOT__/Main.meg"
+    // pub attrs : Vec<HirAttr>,
+    pub item_type: HirItemType,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum HirItemType {
+    Fn(HirFn),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HirFn {
+    // pub params: Vec<HirFnParam>,
+    pub body: Vec<HirStmt>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum HirStmt {
+    Expr(HirExpr),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum HirExpr {
+    CallFunc(HirCallFunc),
+    LitStr(String),
+    LitInt(f64),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HirCallFunc {
+    pub name: Vec<String>,
+    pub args: Vec<HirExpr>,
 }


### PR DESCRIPTION
(Implement into_hir function)
This pull request adds the implementation of the `into_hir` function, which converts the AST (Abstract Syntax Tree) into the HIR (High-level Intermediate Representation) in the given context. It also includes the necessary dependencies and helper functions.
(by copilot)

TODO: add deps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced code conversion process, translating parsed code into a high-level intermediate representation for better analysis and debugging.
	- Implemented a new debugging command that allows inspection of parsing and conversion results.

- **Refactor**
	- Renamed key structures for clarity and consistency across the codebase.
	- Updated internal conversion functions and data structures to improve the transformation of code into intermediate representations.

- **Bug Fixes**
	- Fixed an issue in a test function to properly reflect intended behavior.

- **Style**
	- Adjusted code styling for better readability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->